### PR TITLE
Extract the "m" variable from Consumer

### DIFF
--- a/src/Descriptive/Char.hs
+++ b/src/Descriptive/Char.hs
@@ -14,7 +14,7 @@ import           Data.Text (Text)
 import qualified Data.Text as T
 
 -- | Consume any character.
-anyChar :: Consumer [Char] Text Char
+anyChar :: Monad m => Consumer [Char] Text m Char
 anyChar =
   consumer (return d)
            (do s <- get
@@ -25,7 +25,7 @@ anyChar =
   where d = Unit "a character"
 
 -- | A character consumer.
-char :: Char -> Consumer [Char] Text Char
+char :: Monad m => Char -> Consumer [Char] Text m Char
 char c =
   wrap (liftM (const d))
        (\_ p ->
@@ -41,7 +41,7 @@ char c =
   where d = Unit (T.singleton c)
 
 -- | A string consumer.
-string :: [Char] -> Consumer [Char] Text [Char]
+string :: Monad m => [Char] -> Consumer [Char] Text m [Char]
 string =
   wrap (liftM (Sequence . flattenAnds))
        (\_ p -> p) .

--- a/src/Descriptive/Form.hs
+++ b/src/Descriptive/Form.hs
@@ -26,7 +26,7 @@ data Form
   deriving (Show,Eq)
 
 -- | Consume any input value.
-input :: Text -> Consumer (Map Text Text) Form Text
+input :: Monad m => Text -> Consumer (Map Text Text) Form m Text
 input name =
   consumer (return d)
            (do s <- get

--- a/src/Descriptive/Formlet.hs
+++ b/src/Descriptive/Formlet.hs
@@ -31,7 +31,7 @@ data FormletState =
   deriving (Show,Eq)
 
 -- | Consume any character.
-indexed :: Consumer FormletState Formlet Text
+indexed :: Monad m => Consumer FormletState Formlet m Text
 indexed =
   consumer (do i <- nextIndex
                return (d i))

--- a/src/Descriptive/JSON.hs
+++ b/src/Descriptive/JSON.hs
@@ -62,9 +62,10 @@ data Doc
   deriving (Eq,Show,Typeable,Data)
 
 -- | Consume an object.
-object :: Text -- ^ Description of what the object is.
-       -> Consumer Object Doc a -- ^ An object consumer.
-       -> Consumer Value Doc a
+object :: Monad m
+       => Text -- ^ Description of what the object is.
+       -> Consumer Object Doc m a -- ^ An object consumer.
+       -> Consumer Value Doc m a
 object desc =
   wrap (\d ->
           do s <- get
@@ -92,9 +93,10 @@ object desc =
   where doc = Object desc
 
 -- | Consume from object at the given key.
-key :: Text -- ^ The key to lookup.
-    -> Consumer Value Doc a -- ^ A value consumer of the object at the key.
-    -> Consumer Object Doc a
+key :: Monad m
+    => Text -- ^ The key to lookup.
+    -> Consumer Value Doc m a -- ^ A value consumer of the object at the key.
+    -> Consumer Object Doc m a
 key k =
   wrap (\d ->
           do s <- get
@@ -117,9 +119,10 @@ key k =
 
 -- | Optionally consume from object at the given key, only if it
 -- exists.
-keyMaybe :: Text -- ^ The key to lookup.
-         -> Consumer Value Doc a -- ^ A value consumer of the object at the key.
-         -> Consumer Object Doc (Maybe a)
+keyMaybe :: Monad m
+         => Text -- ^ The key to lookup.
+         -> Consumer Value Doc m a -- ^ A value consumer of the object at the key.
+         -> Consumer Object Doc m (Maybe a)
 keyMaybe k =
   wrap (\d ->
           do s <- get
@@ -141,9 +144,10 @@ keyMaybe k =
   where doc = Key k
 
 -- | Consume an array.
-array :: Text -- ^ Description of this array.
-      -> Consumer Value Doc a -- ^ Consumer for each element in the array.
-      -> Consumer Value Doc (Vector a)
+array :: Monad m
+      => Text -- ^ Description of this array.
+      -> Consumer Value Doc m a -- ^ Consumer for each element in the array.
+      -> Consumer Value Doc m (Vector a)
 array desc =
   wrap (\d -> liftM (Wrap doc) d)
        (\_ p ->
@@ -172,8 +176,9 @@ array desc =
   where doc = Array desc
 
 -- | Consume a string.
-string :: Text -- ^ Description of what the string is for.
-       -> Consumer Value Doc Text
+string :: Monad m
+       => Text -- ^ Description of what the string is for.
+       -> Consumer Value Doc m Text
 string doc =
   consumer (return d)
            (do s <- get
@@ -184,8 +189,9 @@ string doc =
   where d = Unit (Text doc)
 
 -- | Consume an integer.
-integer :: Text -- ^ Description of what the integer is for.
-        -> Consumer Value Doc Integer
+integer :: Monad m
+        => Text -- ^ Description of what the integer is for.
+        -> Consumer Value Doc m Integer
 integer doc =
   consumer (return d)
            (do s <- get
@@ -197,8 +203,9 @@ integer doc =
   where d = Unit (Integer doc)
 
 -- | Consume an double.
-double :: Text -- ^ Description of what the double is for.
-       -> Consumer Value Doc Double
+double :: Monad m
+       => Text -- ^ Description of what the double is for.
+       -> Consumer Value Doc m Double
 double doc =
   consumer (return d)
            (do s <- get
@@ -209,8 +216,9 @@ double doc =
   where d = Unit (Double doc)
 
 -- | Parse a boolean.
-bool :: Text -- ^ Description of what the bool is for.
-     -> Consumer Value Doc Bool
+bool :: Monad m
+     => Text -- ^ Description of what the bool is for.
+     -> Consumer Value Doc m Bool
 bool doc =
   consumer (return d)
            (do s <- get
@@ -221,8 +229,9 @@ bool doc =
   where d = Unit (Boolean doc)
 
 -- | Expect null.
-null :: Text -- ^ What the null is for.
-       -> Consumer Value Doc ()
+null :: Monad m
+     => Text -- ^ What the null is for.
+     -> Consumer Value Doc m ()
 null doc =
   consumer (return d)
            (do s <- get
@@ -233,9 +242,10 @@ null doc =
   where d = Unit (Null doc)
 
 -- | Wrap a consumer with a label e.g. a type tag.
-label :: Text             -- ^ Some label.
-      -> Consumer s Doc a -- ^ A value consumer.
-      -> Consumer s Doc a
+label :: Monad m
+      => Text               -- ^ Some label.
+      -> Consumer s Doc m a -- ^ A value consumer.
+      -> Consumer s Doc m a
 label desc =
   wrap (liftM (Wrap doc))
        (\_ p ->
@@ -247,9 +257,10 @@ label desc =
   where doc = Label desc
 
 -- | Wrap a consumer with some handy information.
-info :: Text             -- ^ Some information.
-     -> Consumer s Doc a -- ^ A value consumer.
-     -> Consumer s Doc a
+info :: Monad m
+     => Text               -- ^ Some information.
+     -> Consumer s Doc m a -- ^ A value consumer.
+     -> Consumer s Doc m a
 info desc =
   wrap (liftM (Wrap doc))
        (\_ p ->

--- a/src/Descriptive/Options.hs
+++ b/src/Descriptive/Options.hs
@@ -46,9 +46,10 @@ data Option a
 
 -- | If the consumer succeeds, stops the whole parser and returns
 -- 'Stopped' immediately.
-stop :: Consumer [Text] (Option a) a
+stop :: Monad m
+     => Consumer [Text] (Option a) m a
      -- ^ A parser which, when it succeeds, causes the whole parser to stop.
-     -> Consumer [Text] (Option a) ()
+     -> Consumer [Text] (Option a) m ()
 stop =
   wrap (liftM (Wrap Stops))
        (\d p ->
@@ -66,8 +67,9 @@ stop =
 
 -- | Consume one argument from the argument list and pops it from the
 -- start of the list.
-anyString :: Text -- Help for the string.
-          -> Consumer [Text] (Option a) Text
+anyString :: Monad m
+          => Text -- Help for the string.
+          -> Consumer [Text] (Option a) m Text
 anyString help =
   consumer (return d)
            (do s <- get
@@ -79,10 +81,11 @@ anyString help =
 
 -- | Consume one argument from the argument list which must match the
 -- given string, and also pops it off the argument list.
-constant :: Text -- ^ String.
+constant :: Monad m
+         => Text -- ^ String.
          -> Text -- ^ Description.
          -> v
-         -> Consumer [Text] (Option a) v
+         -> Consumer [Text] (Option a) m v
 constant x' desc v =
   consumer (return d)
            (do s <- get
@@ -95,10 +98,11 @@ constant x' desc v =
 
 -- | Find a value flag which must succeed. Removes it from the
 -- argument list if it succeeds.
-flag :: Text -- ^ Name.
+flag :: Monad m
+     => Text -- ^ Name.
      -> Text -- ^ Description.
      -> v    -- ^ Value returned when present.
-     -> Consumer [Text] (Option a) v
+     -> Consumer [Text] (Option a) m v
 flag name help v =
   consumer (return d)
            (do s <- get
@@ -110,18 +114,20 @@ flag name help v =
 
 -- | Find a boolean flag. Always succeeds. Omission counts as
 -- 'False'. Removes it from the argument list if it returns True.
-switch :: Text -- ^ Name.
+switch :: Monad m
+       => Text -- ^ Name.
        -> Text -- ^ Description.
-       -> Consumer [Text] (Option a) Bool
+       -> Consumer [Text] (Option a) m Bool
 switch name help =
   flag name help True <|>
   pure False
 
 -- | Find an argument prefixed by -X. Removes it from the argument
 -- list when it succeeds.
-prefix :: Text -- ^ Prefix string.
+prefix :: Monad m
+       => Text -- ^ Prefix string.
        -> Text -- ^ Description.
-       -> Consumer [Text] (Option a) Text
+       -> Consumer [Text] (Option a) m Text
 prefix pref help =
   consumer (return d)
            (do s <- get
@@ -133,9 +139,10 @@ prefix pref help =
 
 -- | Find a named argument e.g. @--name value@. Removes it from the
 -- argument list when it succeeds.
-arg :: Text -- ^ Name.
+arg :: Monad m
+    => Text -- ^ Name.
     -> Text -- ^ Description.
-    -> Consumer [Text] (Option a) Text
+    -> Consumer [Text] (Option a) m Text
 arg name help =
   consumer (return d)
            (do s <- get


### PR DESCRIPTION
The following example proves that with this update effectful parsing becomes possible:
```haskell
λ>flip evalStateT (Data.Map.fromList [("aa", "123")]) $ runConsumer $ validate (Constraint "-") (\_ -> fmap Just $ liftIO $ readLn) (input "aa") :: IO (Result (Description Form) Int)
3
Succeeded 3
```