### PR TITLE
Add semigroups dependency for GHC < 8.0.1

### DIFF
--- a/descriptive.cabal
+++ b/descriptive.cabal
@@ -33,6 +33,8 @@ library
                    , text
                    , transformers
                    , vector
+  if impl(ghc < 8.0.1)
+    build-depends: semigroups
 
 test-suite test
     type: exitcode-stdio-1.0


### PR DESCRIPTION
The `import Data.Monoid` needs `semigroups` for `base` < 4.9 (i.e. GHC < 8.0.1)